### PR TITLE
Fix link to point github repository, not git.typo3.org

### DIFF
--- a/Documentation/NeedSupport/Index.rst
+++ b/Documentation/NeedSupport/Index.rst
@@ -20,7 +20,7 @@ Contribute
 
 Any contribution is highly welcomed! Please use the mentioned issue tracker!
 
-The git repository is located at https://git.typo3.org/TYPO3CMS/Extensions/eventnews.git.
+The git repository is located at https://github.com/georgringer/eventnews
 
 Sponsoring
 ----------


### PR DESCRIPTION
Since TYPO3 Dev Days 2016, github has been the recommended place to have repositories, so this pull request updates that.

I have not changed the issue tracker link, which currently points to forge.typo3.org. Maybe that should point to github too..?