### PR TITLE
Events with enddate in the future are missing in list view

### DIFF
--- a/Classes/Hooks/AbstractDemandedRepository.php
+++ b/Classes/Hooks/AbstractDemandedRepository.php
@@ -98,6 +98,14 @@ class AbstractDemandedRepository
                 $converted += 86350;
                 $constraints[] = $query->lessThanOrEqual('datetime', $converted);
             }
+            // Time restriction to include events with startdate in the past AND enddate in the future!
+            if ($demand->getTimeRestriction()) {
+                $timeLimit = \GeorgRinger\News\Utility\ConstraintHelper::getTimeRestrictionLow($demand->getTimeRestriction());
+                $constraints['timeRestrictionGreater'] = $query->greaterThanOrEqual(
+                    'eventEnd',
+                    $timeLimit
+                );
+            }
         }
     }
 


### PR DESCRIPTION
If the start date is in the past AND the end date is in the future, the event is not shown in the list view.
To display all the current events (events over several days), you need to add the following code.
best regards, Stephan