### PR TITLE
[BUGFIX] fix "no constraint" eventRestriction in flexforms

### DIFF
--- a/Configuration/Flexforms/flexform_eventnews.xml
+++ b/Configuration/Flexforms/flexform_eventnews.xml
@@ -7,14 +7,18 @@
                 <renderType>selectSingle</renderType>
                 <items>
                     <numIndex index="0" type="array">
-                        <numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.no-constraint</numIndex>
+                        <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.fallback</numIndex>
                         <numIndex index="1"></numIndex>
                     </numIndex>
-                    <numIndex index="1">
+                    <numIndex index="1" type="array">
+                        <numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.no-constraint</numIndex>
+                        <numIndex index="1">3</numIndex>
+                    </numIndex>
+                    <numIndex index="2">
                         <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.1</numIndex>
                         <numIndex index="1">1</numIndex>
                     </numIndex>
-                    <numIndex index="2">
+                    <numIndex index="3">
                         <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.2</numIndex>
                         <numIndex index="1">2</numIndex>
                     </numIndex>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="flexforms_general.eventRestriction">
 				<source>Event Restriction</source>
 			</trans-unit>
+			<trans-unit id="flexforms_general.fallback">
+				<source>Defined in TypoScript</source>
+			</trans-unit>
 			<trans-unit id="flexforms_general.eventRestriction.1">
 				<source>Only events</source>
 			</trans-unit>


### PR DESCRIPTION
The value of the "no constraint" option in the flexforms config was empty and so the value was always set to the value configured in TS.

Now the "no constraint" option now has a defined value (=3) to override the default setting.
The default empty option is labeled as "Defined in TypoScript"