### PR TITLE
Remove unneccessary comma in TCA configuration

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -93,4 +93,4 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['palette_event'] = [
 $GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['requestUpdate'] .= ',is_event';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', 'is_event,--palette--;;palette_event,', '', 'after:title');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', 'is_event,--palette--;;palette_event', '', 'after:title');


### PR DESCRIPTION
There is a trailing comma in the new fields string of method `addToAllTCATypes` that is unneccessary. It leads to a double comma in the final `showitem` string: `title, is_event, --palette--;;palette_event, ,--palette--;;paletteCore,teaser,`. Even if it doesn't break anything it should be removed.