### PR TITLE
[BUGFIX] Add demand overrides for year and month

### DIFF
--- a/Resources/Private/Templates/News/Month.html
+++ b/Resources/Private/Templates/News/Month.html
@@ -183,7 +183,7 @@
 			<f:if condition="{day.news}">
 				<f:then>
 					<strong>
-						<f:link.action action="month" addQueryString="1" additionalParams="{tx_news_pi1:{overwriteDemand:{day:day.day}}}">{day.day}</f:link.action>
+						<f:link.action action="month" addQueryString="1" additionalParams="{tx_news_pi1:{overwriteDemand:{year:day.year,month:day.month,day:day.day}}}">{day.day}</f:link.action>
 					</strong>
 
 					<f:for each="{day.news}" as="newsItem">


### PR DESCRIPTION
This adds the proposed changes to the `calday` section links in the Month view from issue #38. Contrary to given comments, VHS is not required in the template and just setting the override demand to the proper values fixes the day-view again.