### PR TITLE
Bugfix: Remove hardcoded path to flexform file

### DIFF
--- a/Classes/Hooks/FlexFormHook.php
+++ b/Classes/Hooks/FlexFormHook.php
@@ -3,6 +3,7 @@
 namespace GeorgRinger\Eventnews\Hooks;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 class FlexFormHook
 {
@@ -14,7 +15,7 @@ class FlexFormHook
     public function parseDataStructureByIdentifierPostProcess(array $dataStructure, array $identifier)
     {
         if ($identifier['type'] === 'tca' && $identifier['tableName'] === 'tt_content' && $identifier['dataStructureKey'] === 'news_pi1,list') {
-            $file = PATH_site . 'typo3conf/ext/eventnews/Configuration/Flexforms/flexform_eventnews.xml';
+            $file = ExtensionManagementUtility::extPath('eventnews') . 'Configuration/Flexforms/flexform_eventnews.xml';
             $content = file_get_contents($file);
             if ($content) {
                 $dataStructure['sheets']['extraEntry'] = GeneralUtility::xml2array($content);


### PR DESCRIPTION
In the class FlexFormHook the path to the file "flexform_eventnews.xml" is hardcoded. It's probably better to do it with extPath.