### PR TITLE
[TASK] TCA update from requestUpdate to onChange

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -7,6 +7,7 @@ $fields = [
     'is_event' => [
         'exclude' => true,
         'label' => 'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tx_eventnews_domain_model_news.is_event',
+        'onChange' => 'reload',
         'config' => [
             'type' => 'check',
             'default' => 0
@@ -95,7 +96,6 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['palette_eventfields'] 
     'canNotCollapse' => true,
     'showitem' => 'organizer,organizer_simple, --linebreak--,location,location_simple'
 ];
-$GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['requestUpdate'] .= ',is_event';
 $GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['typeicon_classes']['userFunc'] = \GeorgRinger\Eventnews\Hooks\IconHook::class . '->run';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);


### PR DESCRIPTION
The TCA setting ['ctrl']['requestUpdate'] was removed from table tx_news_domain_model_news. The column field(s) "" and "is_event" were updated and contain option "'onChange' => 'reload'" parallel to 'config' and 'label' section.