### PR TITLE
Change position for adding of Event Details tab to teaser

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -100,4 +100,4 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['typeicon_classes']['userFu
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', 'is_event,--palette--;;palette_event', '', 'after:datetime');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'after:bodytext');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'after:teaser');


### PR DESCRIPTION
Since the bodytext field is not available under External and Internal link types, the event details tab is placed at the back of the list instead of the second tab, like a regular news item. Changing this to teaser will solve the problem, since this field is shown on all types.