### PR TITLE
[TASK] Prevent datetime being set to current time

### DIFF
--- a/Classes/Backend/FormDataProvider/EventNewsRowInitializeNew.php
+++ b/Classes/Backend/FormDataProvider/EventNewsRowInitializeNew.php
@@ -29,6 +29,7 @@ class EventNewsRowInitializeNew implements FormDataProviderInterface
 
         if (is_array($result['pageTsConfig']['tx_news.']) && (bool)$result['pageTsConfig']['tx_news.']['newRecordAsEvent']) {
             $result['databaseRow']['is_event'] = 1;
+            $result['databaseRow']['datetime'] = 0;
         }
 
         return $result;


### PR DESCRIPTION
When creating a new event, it doesn't make sense that the datetime field is filled with the current time.