### PR TITLE
[BUGFIX] correct hidden field in organizer and location

### DIFF
--- a/Configuration/TCA/tx_eventnews_domain_model_location.php
+++ b/Configuration/TCA/tx_eventnews_domain_model_location.php
@@ -89,10 +89,17 @@ return [
         ],
         'hidden' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',
             'config' => [
                 'type' => 'check',
-                'default' => 0
+                'renderType' => 'checkboxToggle',
+                'items' => [
+                    [
+                        0 => '',
+                        1 => '',
+                        'invertStateDisplay' => true
+                    ]
+                ],
             ]
         ],
         'starttime' => [

--- a/Configuration/TCA/tx_eventnews_domain_model_organizer.php
+++ b/Configuration/TCA/tx_eventnews_domain_model_organizer.php
@@ -85,10 +85,17 @@ return [
         ],
         'hidden' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visible',
             'config' => [
                 'type' => 'check',
-                'default' => 0
+                'renderType' => 'checkboxToggle',
+                'items' => [
+                    [
+                        0 => '',
+                        1 => '',
+                        'invertStateDisplay' => true
+                    ]
+                ],
             ]
         ],
         'starttime' => [


### PR DESCRIPTION
Location and Organizer tables had the wrong hidden field TCA. This caused the label to disappear as seen on the screenshot:
![LWR_Recording](https://user-images.githubusercontent.com/8478309/94569383-f4ff6080-026d-11eb-85ec-c754c60b7b21.png)

Corrected this with the default hidden field found in typo3/cms-frontend