### PR TITLE
[BUGFIX] Allow more than 2 decimal places for location lat and lng.

### DIFF
--- a/Configuration/TCA/tx_eventnews_domain_model_location.php
+++ b/Configuration/TCA/tx_eventnews_domain_model_location.php
@@ -155,7 +155,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'double2'
+                'eval' => 'trim'
             ]
         ],
         'lng' => [
@@ -164,7 +164,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'double2'
+                'eval' => 'trim'
             ]
         ],
         'link' => [

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -8,8 +8,8 @@ CREATE TABLE tx_eventnews_domain_model_location (
 
 	title varchar(255) DEFAULT '' NOT NULL,
 	description text NOT NULL,
-	lat double(11,2) DEFAULT '0.00' NOT NULL,
-	lng double(11,2) DEFAULT '0.00' NOT NULL,
+	lat double DEFAULT '0' NOT NULL,
+	lng double DEFAULT '0' NOT NULL,
 	link varchar(255) DEFAULT '' NOT NULL,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Only two decimal places is inaccurate, the locatation may be off by several hundred meters.
The drawback of this change is that lat and lng have to be entered with ".", the automatic replacement of "," by "." does not work.
Fixes #123.