### PR TITLE
[TASK] Remove deprecated code

### DIFF
--- a/Classes/Hooks/BackendUtility.php
+++ b/Classes/Hooks/BackendUtility.php
@@ -24,12 +24,5 @@ class BackendUtility extends \GeorgRinger\News\Hooks\BackendUtility
 
             $this->deleteFromStructure($params['dataStructure'], $removedFields);
         }
-        if ($params['selectedView'] === 'News->month' || $params['selectedView'] === 'News->list') {
-            $eventRestrictionXml = GeneralUtility::xml2array($this->eventRestrictionField);
-            if (is_array($params['dataStructure']['sheets']['sDEF']['ROOT']['el'])) {
-                $params['dataStructure']['sheets']['sDEF']['ROOT']['el'] = $params['dataStructure']['sheets']['sDEF']['ROOT']['el'] + [
-                    'settings.eventRestriction' => $eventRestrictionXml];
-            }
-        }
     }
 }


### PR DESCRIPTION
Since `$eventRestrictionField` is removed this code leads to warnings.
I think it can be removed, the EventRestriction Field will be added from eventnews/Configuration/Flexforms/flexform_eventnews.xml

`Core: Error handler (BE): PHP Warning: Illegal string offset 'config' in /app/web/typo3/sysext/core/Classes/Migrations/TcaMigration.php line 147
`
