### PR TITLE
Put event details tab before "media"

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -99,4 +99,4 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['typeicon_classes']['userFu
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', 'is_event,--palette--;;palette_event', '', 'after:datetime');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'after:teaser');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'before:--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media');


### PR DESCRIPTION
This fixes the location of the `bodytext` which is no longer inside the "Event Details" tab.

This works with any news type, regarless if it has bodytext field.

Resolves #134
