### PR TITLE
Escape locallang path for regex

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -99,4 +99,5 @@ $GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['typeicon_classes']['userFu
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', 'is_event,--palette--;;palette_event', '', 'after:datetime');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'before:--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.media');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tx_news_domain_model_news', ',--div--;LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tab.eventnews,--palette--;;palette_eventfields', '', 'before:--div--;LLL:EXT:frontend\/Resources\/Private\/Language\/locallang_ttc.xlf:tabs.media');
+


### PR DESCRIPTION
the before value is used in a preg_match() call
and therefore needs to be treated as such. So
forward slashes need to be escaped for example.

fixes #146