### PR TITLE
[TASK] Update ext_emconf to match current composer requirements

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '10.4.0-11.5.99',
-            'news' => '9.2.0-9.9.99',
+            'news' => '9.2.0-10.9.9',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This extension threw a warning if you wanted to install it via extension manager in the TYPO3 backend. This was, because the ext_emconf has old constraints in it. It didn't match the composer.json requirements.

Will fix #148 