### PR TITLE
Prevent PHP Warning on PHP 8.1

### DIFF
--- a/Classes/Domain/Model/Dto/Demand.php
+++ b/Classes/Domain/Model/Dto/Demand.php
@@ -38,7 +38,9 @@ class Demand extends NewsDemand
 
     public function __construct(array $settings = null)
     {
-        $this->eventRestriction = $settings['eventRestriction'];
+        if (is_array($settings) && isset($settings['eventRestriction'])) {
+            $this->eventRestriction = $settings['eventRestriction'];
+        }
     }
 
     /**


### PR DESCRIPTION
PHP 8.1 is throwing a Warning "Trying to access array offset on value of type null" when $settings = NULL