### PR TITLE
[BUGFIX] Event restriction is not applied to News subclasses

### DIFF
--- a/Classes/Hooks/AbstractDemandedRepository.php
+++ b/Classes/Hooks/AbstractDemandedRepository.php
@@ -24,7 +24,13 @@ class AbstractDemandedRepository
      */
     public function modify(array $params)
     {
-        if (get_class($params['demand']) !== Demand::class || $params['query']->getType() !== News::class) {
+        if (get_class($params['demand']) !== Demand::class) {
+            return;
+        }
+
+        $queryType = $params['query']->getType();
+
+        if ($queryType !== News::class && !is_subclass_of($queryType, News::class)) {
             return;
         }
 


### PR DESCRIPTION
When using the event restriction (Demand::setEventRestriction) in combination with overwritten News models extending the eventnews ones, the IsEvent check isn't applied. This is due to the additional check added in 32c5dc5dd7dcec521bd5cbd80a8ce4e1571f271a (v6.0.0), which does not account for subclasses.

We manually tested this change with `georgringer/eventnews:6.0.0`,  `georgringer/news:11.1.2 ` and `typo3/cms-core:v11.5.30`.