### PR TITLE
[BUGFIX] Event restriction is not applied to Demand subclasses

### DIFF
--- a/Classes/Hooks/AbstractDemandedRepository.php
+++ b/Classes/Hooks/AbstractDemandedRepository.php
@@ -24,7 +24,7 @@ class AbstractDemandedRepository
      */
     public function modify(array $params)
     {
-        if (get_class($params['demand']) !== Demand::class) {
+        if (!($params['demand'] instanceof Demand)) {
             return;
         }
 


### PR DESCRIPTION
I haven't used the IsEvent restriction in combination with an extended demand class yet, but as a developer extending eventnews I expect the IsEvent restriction to also be effective on subclasses of the eventnews Demand class.

I manually tested this change with georgringer/news:11.1.2 and typo3/cms-core:v11.5.30 by using `\GeorgRinger\Eventnews\Domain\Model\Dto\Demand` for the passing path (the one that applies the restriction) and a direct subclass of `\GeorgRinger\News\Domain\Model\Dto\NewsDemand` for the early-return path.

Resolves: #122