### PR TITLE
Restoring the dropdown for "settings.eventRestriction" in the backend (v11)

### DIFF
--- a/Configuration/Flexforms/flexform_eventnews.xml
+++ b/Configuration/Flexforms/flexform_eventnews.xml
@@ -6,31 +6,29 @@
     <type>array</type>
     <el>
         <settings.eventRestriction>
-            <TCEforms>
-                <label>LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction</label>
-                <config>
-                    <type>select</type>
-                    <renderType>selectSingle</renderType>
-                    <items>
-                        <numIndex index="0" type="array">
-                            <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.fallback</numIndex>
-                            <numIndex index="1"></numIndex>
-                        </numIndex>
-                        <numIndex index="1" type="array">
-                            <numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.no-constraint</numIndex>
-                            <numIndex index="1">3</numIndex>
-                        </numIndex>
-                        <numIndex index="2">
-                            <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.1</numIndex>
-                            <numIndex index="1">1</numIndex>
-                        </numIndex>
-                        <numIndex index="3">
-                            <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.2</numIndex>
-                            <numIndex index="1">2</numIndex>
-                        </numIndex>
-                    </items>
-                </config>
-            </TCEforms>
+            <label>LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction</label>
+            <config>
+                <type>select</type>
+                <renderType>selectSingle</renderType>
+                <items>
+                    <numIndex index="0" type="array">
+                        <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.fallback</numIndex>
+                        <numIndex index="1"></numIndex>
+                    </numIndex>
+                    <numIndex index="1" type="array">
+                        <numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.no-constraint</numIndex>
+                        <numIndex index="1">3</numIndex>
+                    </numIndex>
+                    <numIndex index="2">
+                        <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.1</numIndex>
+                        <numIndex index="1">1</numIndex>
+                    </numIndex>
+                    <numIndex index="3">
+                        <numIndex index="0">LLL:EXT:eventnews/Resources/Private/Language/locallang.xlf:flexforms_general.eventRestriction.2</numIndex>
+                        <numIndex index="1">2</numIndex>
+                    </numIndex>
+                </items>
+            </config>
         </settings.eventRestriction>
     </el>
 </ROOT>


### PR DESCRIPTION
Contrary to some instructions on the web, extending Flexform fields for version 11 does not include an additional definition of `<TCEforms></TCEforms>` within an element. See: https://docs.typo3.org/p/georgringer/news/11.1/en-us/Tutorials/ExtendNews/ExtendFlexforms/Index.html

By removing this element, the flexform field will be displayed correctly again in the backend of TYPO3 v11.