### PR TITLE
[TASK] Prevent PHP warning if categories not available in FlexForm

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -41,7 +41,7 @@ class NewsController extends \GeorgRinger\News\Controller\NewsController
         $newsRecordsWithDaySupport = $this->newsRepository->findDemanded($demand);
         $demand->setRespectDay(false);
         $newsRecordsWithNoDaySupport = $this->newsRepository->findDemanded($demand);
-        $categories = GeneralUtility::trimExplode(',', $this->settings['categories'], true);
+        $categories = GeneralUtility::trimExplode(',', $this->settings['categories'] ?? [], true);
 
         /** @var CategoryRepository $categoryRepository */
         $categoryRepository = $this->categoryRepository;


### PR DESCRIPTION
This change adds a fallback for the `categories` FlexForm field, which may be empty under rare circumstances.