### PR TITLE
[BUGFIX] Fix locallangXMLOverride of default language

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,6 +45,10 @@ $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes']['Domain/Model/News'][] = '
 // override language files of news
 $overrideModuleLable = (bool)\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('eventnews', 'overrideAdministrationModuleLabel');
 if ($overrideModuleLable) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['default']['EXT:news/Resources/Private/Language/locallang_modadministration.xlf'][] = 'EXT:eventnews/Resources/Private/Language/Overrides/locallang_modadministration.xlf';
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']['EXT:news/Resources/Private/Language/locallang_modadministration.xlf'][] = 'EXT:eventnews/Resources/Private/Language/Overrides/de.locallang_modadministration.xlf';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']
+        ['EXT:news/Resources/Private/Language/locallang_modadministration.xlf'][]
+            = 'EXT:eventnews/Resources/Private/Language/Overrides/locallang_modadministration.xlf';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']
+        ['EXT:news/Resources/Private/Language/locallang_modadministration.xlf'][]
+            = 'EXT:eventnews/Resources/Private/Language/Overrides/de.locallang_modadministration.xlf';
 }


### PR DESCRIPTION
According to the documentation, the standard language is defined without specifying an additional key `default`.

See: https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Localization/ManagingTranslations.html#custom-translations