### PR TITLE
Forward to detailAction if eventnews item is selected

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,43 +1,52 @@
 <?php
 
-$pluginName = 'news_month';
-$pluginNameForLabel = $pluginName === 'pi1' ? 'news_list' : $pluginName;
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'eventnews',
-    'NewsMonth',
-    'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.news_month.title',
-    'ext-news-type-event',
-    'news',
-    'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.news_month.description',
-);
+use GeorgRinger\News\Hooks\PluginPreviewRenderer;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
-$contentTypeName = 'eventnews_newsmonth';
+defined('TYPO3') or die;
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    '*',
-    'FILE:EXT:news/Configuration/FlexForms/flexform_news_list.xml',
-    'eventnews_newsmonth'
-);
-$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes'][$contentTypeName] = 'ext-news-plugin-' . str_replace('_', '-', $pluginNameForLabel);
-
-$GLOBALS['TCA']['tt_content']['types'][$contentTypeName]['previewRenderer'] = \GeorgRinger\News\Hooks\PluginPreviewRenderer::class;
-$GLOBALS['TCA']['tt_content']['types'][$contentTypeName]['showitem'] = '
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-            --palette--;;general,
-            --palette--;;headers,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin,
-            pi_flexform,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
-            --palette--;;frames,
-            --palette--;;appearanceLinks,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-            --palette--;;language,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
-            --palette--;;hidden,
-            --palette--;;access,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
-            categories,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
-            rowDescription,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
-    ';
+$pluginConfig = ['news_month', 'news_month_detail'];
+foreach ($pluginConfig as $pluginName) {
+    $pluginNameForLabel = $pluginName === 'pi1' ? 'news_list' : $pluginName;
+    ExtensionUtility::registerPlugin(
+        'eventnews',
+        GeneralUtility::underscoredToUpperCamelCase($pluginName),
+        'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.' . $pluginNameForLabel . '.title',
+        'ext-news-type-event',
+        'news',
+        'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.' . $pluginNameForLabel . '.description',
+    );
+    
+    $contentTypeName = 'eventnews_' . str_replace('_', '', $pluginName);
+    
+    ExtensionManagementUtility::addPiFlexFormValue(
+        '*',
+        'FILE:EXT:news/Configuration/FlexForms/flexform_news_list.xml',
+        $contentTypeName
+    );
+    $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes'][$contentTypeName] = 'ext-news-plugin-' . str_replace('_', '-', $pluginNameForLabel);
+    
+    $GLOBALS['TCA']['tt_content']['types'][$contentTypeName]['previewRenderer'] = PluginPreviewRenderer::class;
+    $GLOBALS['TCA']['tt_content']['types'][$contentTypeName]['showitem'] = '
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+                --palette--;;general,
+                --palette--;;headers,
+            --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin,
+                pi_flexform,
+            --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
+                --palette--;;frames,
+                --palette--;;appearanceLinks,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                --palette--;;language,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+                --palette--;;hidden,
+                --palette--;;access,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
+                categories,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+                rowDescription,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+        ';
+}

--- a/Configuration/TSconfig/ContentElementWizard.tsconfig
+++ b/Configuration/TSconfig/ContentElementWizard.tsconfig
@@ -8,5 +8,13 @@ mod.wizards.newContentElement.wizardItems.ext-news {
                 CType = eventnews_newsmonth
             }
         }
+        news_month_detail {
+            iconIdentifier = ext-news-type-event
+            title = LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.news_month_detail.title
+            description = LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:plugin.news_month_detail.description
+            tt_content_defValues {
+                CType = eventnews_newsmonthdetail
+            }
+        }
     }
 }

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -7,7 +7,15 @@
 				<source>Month view provided by EXT:eventnews</source>
 			</trans-unit>
 			<trans-unit id="plugin.news_month.description" xml:space="preserve">
-				<source>Month calendar sheet with articles flagged as event</source>
+				<source>Month calendar sheet with articles flagged as event
+					This plugin cannot render the detail view of news articles.</source>
+			</trans-unit>
+			<trans-unit id="plugin.news_month_detail.title" xml:space="preserve">
+				<source>Month view provided by EXT:eventnews (incl. detail view)</source>
+			</trans-unit>
+			<trans-unit id="plugin.news_month_detail.description" xml:space="preserve">
+				<source>Month calendar sheet with articles flagged as event
+					This plugin is capable of rendering the detail view as well.</source>
 			</trans-unit>
 			<trans-unit id="tx_eventnews_domain_model_location">
 				<source>Location</source>
@@ -57,7 +65,7 @@
 			<trans-unit id="tx_news_domain_model_news.location_simple">
 				<source>Location simple</source>
 			</trans-unit>
-            <trans-unit id="tab.eventnews">
+			<trans-unit id="tab.eventnews">
 				<source>Event details</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Templates/News/Month.html
+++ b/Resources/Private/Templates/News/Month.html
@@ -147,7 +147,10 @@
 <f:section name="listItem">
 	<div class="col-md-12" style="border: 1px solid #ccc;">
 		<strong>
-			<n:link newsItem="{n}" settings="{settings}">{n.title}</n:link>
+			<f:if condition="{contentObjectData.CType} == 'eventnews_newsmonth' || {contentObjectData.pid} != {settings.detailPid}">
+				<f:then><n:link newsItem="{n}" settings="{settings}">{n.title}</n:link></f:then>
+				<f:else><f:link.action action="month" arguments="{news:n}">{n.title}</f:link.action></f:else>
+			</f:if>
 			| {f:format.date(date:n.datetime,format:'%d.%m')}</strong>
 		<ul>
 			<f:if condition="{n.organizer}">

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,30 +1,54 @@
 <?php
 
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+use GeorgRinger\Eventnews\Backend\FormDataProvider\EventNewsRowInitializeNew;
+use GeorgRinger\Eventnews\Controller\NewsController;
+use GeorgRinger\Eventnews\Hooks\FormEngineHook;
+use GeorgRinger\Eventnews\Hooks\PageLayoutView;
+use GeorgRinger\Eventnews\Hooks\Backend\EventNewsDataHandlerHook;
+use GeorgRinger\News\Hooks\PluginPreviewRenderer;
+use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
+defined('TYPO3') or die;
+
+ExtensionUtility::configurePlugin(
     'Eventnews',
     'NewsMonth',
     [
-        \GeorgRinger\Eventnews\Controller\NewsController::class => 'month',
+        NewsController::class => 'month',
     ],
     [],
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
+    ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
+);
+ExtensionUtility::configurePlugin(
+    'Eventnews',
+    'NewsMonthDetail',
+    [
+        NewsController::class => 'month,detail',
+    ],
+    [],
+    ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
 );
 
 // Hide not needed fields in FormEngine
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tceforms.php']['getSingleFieldClass']['eventnews']
-    = \GeorgRinger\Eventnews\Hooks\FormEngineHook::class;
+    = FormEngineHook::class;
 
-$GLOBALS['TYPO3_CONF_VARS']['EXT']['news'][\GeorgRinger\News\Hooks\PluginPreviewRenderer::class]['extensionSummary']['eventnews']
-    = \GeorgRinger\Eventnews\Hooks\PageLayoutView::class . '->extensionSummary';
+$GLOBALS['TYPO3_CONF_VARS']['EXT']['news'][PluginPreviewRenderer::class]['extensionSummary']['eventnews']
+    = PageLayoutView::class . '->extensionSummary';
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\GeorgRinger\Eventnews\Backend\FormDataProvider\EventNewsRowInitializeNew::class] = [
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][EventNewsRowInitializeNew::class] = [
     'depends' => [
-        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class,
+        DatabaseRowInitializeNew::class,
     ]
 ];
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['eventnews'] =
-    \GeorgRinger\Eventnews\Hooks\Backend\EventNewsDataHandlerHook::class;
+    EventNewsDataHandlerHook::class;
 
 /***********
  * Extend EXT:news
@@ -32,13 +56,13 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['proc
 
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes']['Domain/Model/News'][] = 'eventnews';
 
-if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 13) {
+if ((new Typo3Version())->getMajorVersion() < 13) {
     // @extensionScannerIgnoreLine
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('@import \'EXT:eventnews/Configuration/TSconfig/ContentElementWizard.tsconfig\'');
+    ExtensionManagementUtility::addPageTSConfig('@import \'EXT:eventnews/Configuration/TSconfig/ContentElementWizard.tsconfig\'');
 }
 
 // override language files of news
-$overrideModuleLable = (bool)\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('eventnews', 'overrideAdministrationModuleLabel');
+$overrideModuleLable = (bool)GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('eventnews', 'overrideAdministrationModuleLabel');
 if ($overrideModuleLable) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']
         ['EXT:news/Resources/Private/Language/locallang_modadministration.xlf'][]


### PR DESCRIPTION
This solves #174 by adding an additional plugin. If the month action is called with a eventnews item as an argument, the request is forwarded to the detail action. So one can spare an additional detail page or content element.

I had to override the functions [forwardToDetailActionWhenRequested](https://github.com/georgringer/news/blob/32afe5d5f0cb15b5fb222af15313ba064aeec041/Classes/Controller/NewsController.php#L278) and [isActionAllowed](https://github.com/georgringer/news/blob/32afe5d5f0cb15b5fb222af15313ba064aeec041/Classes/Controller/NewsController.php#L293) because they either only worked for EXT:news (forwardToDetailActionWhenRequested) or probably not at all (isActionAllowed)...