### PR TITLE
[FEATURE] Add tsconfig to restrict allowed tables to eventnews related

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,3 +9,9 @@ $GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [
     'icon' => 'apps-pagetree-folder-contains-eventnews',
 ];
 $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-eventnews'] = 'apps-pagetree-folder-contains-eventnews';
+
+ExtensionManagementUtility::registerPageTSConfigFile(
+    'eventnews',
+    'Configuration/TSconfig/eventnews_only.tsconfig',
+    'EXT:eventnews :: Restrict pages to eventnews records'
+);

--- a/Configuration/TCA/tx_eventnews_domain_model_location.php
+++ b/Configuration/TCA/tx_eventnews_domain_model_location.php
@@ -110,8 +110,7 @@ $tx_eventnews_domain_model_location = [
             'label' => 'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tx_eventnews_domain_model_location.description',
             'config' => [
                 'type' => 'text',
-                'cols' => 30,
-                'rows' => 4,
+                'enableRichtext' => true,
                 'eval' => 'trim',
             ],
         ],

--- a/Configuration/TCA/tx_eventnews_domain_model_organizer.php
+++ b/Configuration/TCA/tx_eventnews_domain_model_organizer.php
@@ -106,9 +106,7 @@ $tx_eventnews_domain_model_organizer = [
             'label' => 'LLL:EXT:eventnews/Resources/Private/Language/locallang_db.xlf:tx_eventnews_domain_model_organizer.description',
             'config' => [
                 'type' => 'text',
-                'cols' => 30,
-                'rows' => 4,
-                'eval' => 'trim',
+                'enableRichtext' => true,
             ],
         ],
         'link' => [

--- a/Configuration/TSconfig/eventnews_only.tsconfig
+++ b/Configuration/TSconfig/eventnews_only.tsconfig
@@ -1,0 +1,1 @@
+mod.web_list.allowedNewTables := addToList(tx_news_domain_model_news,sys_note,tx_news_domain_model_tag,tx_eventnews_domain_model_location,tx_eventnews_domain_model_organizer)


### PR DESCRIPTION
Works exactly like `news_only.tsconfig` from `EXT:news`, but additionally allows the use of tables for `tx_eventnews_domain_model_location` and `tx_eventnews_domain_model_organizer `