### PR TITLE
[BUGFIX] Fallback to empty string when no category

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -43,7 +43,7 @@ class NewsController extends \GeorgRinger\News\Controller\NewsController
         $newsRecordsWithDaySupport = $this->newsRepository->findDemanded($demand);
         $demand->setRespectDay(false);
         $newsRecordsWithNoDaySupport = $this->newsRepository->findDemanded($demand);
-        $categories = GeneralUtility::trimExplode(',', $this->settings['categories'] ?? [], true);
+        $categories = GeneralUtility::trimExplode(',', $this->settings['categories'] ?? '', true);
 
         /** @var CategoryRepository $categoryRepository */
         $categoryRepository = $this->categoryRepository;


### PR DESCRIPTION
With TYPO3 core #101305, native types for function arguments have been added to `GeneralUtility::trimExplode`. This leads to a problem in ext:eventnews, because the fallback implemented 2 years ago falls back to an empty array instead of an empty string. Since the `trimExplode` function expects a string as 2nd argument, the extension will fail with an exception, if no category is defined.